### PR TITLE
Add email OTP support for authentication

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
@@ -67,6 +71,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.40</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -79,8 +84,32 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.40</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/backend/src/main/java/com/school/erp/config/MailConfig.java
+++ b/backend/src/main/java/com/school/erp/config/MailConfig.java
@@ -1,0 +1,32 @@
+package com.school.erp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername("noreply.eschool365@gmail.com");
+        mailSender.setPassword("yuorihbubvnrnagk");
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.starttls.required", "true");
+        props.put("mail.smtp.connectiontimeout", "5000");
+        props.put("mail.smtp.timeout", "5000");
+        props.put("mail.smtp.writetimeout", "5000");
+
+        return mailSender;
+    }
+}

--- a/backend/src/main/java/com/school/erp/controller/AuthController.java
+++ b/backend/src/main/java/com/school/erp/controller/AuthController.java
@@ -34,7 +34,21 @@ public class AuthController {
 
     @PostMapping("/request-otp")
     public ResponseEntity<Map<String, String>> requestOtp(@Valid @RequestBody OtpRequestDto request) {
-        otpService.generateAndSendOtp(request.getPhone());
+        // Validate that either phone or email is provided
+        if ((request.getPhone() == null || request.getPhone().trim().isEmpty()) &&
+            (request.getEmail() == null || request.getEmail().trim().isEmpty())) {
+            Map<String, String> error = new HashMap<>();
+            error.put("error", "Either phone number or email is required");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+        }
+
+        if (request.getPhone() != null && !request.getPhone().trim().isEmpty()) {
+            // Send OTP via phone
+            otpService.generateAndSendOtp(request.getPhone());
+        } else if (request.getEmail() != null && !request.getEmail().trim().isEmpty()) {
+            // Send OTP via email
+            otpService.generateAndSendOtpByEmail(request.getEmail());
+        }
         
         Map<String, String> response = new HashMap<>();
         response.put("message", "OTP sent successfully");
@@ -43,7 +57,27 @@ public class AuthController {
 
     @PostMapping("/verify-otp")
     public ResponseEntity<?> verifyOtp(@Valid @RequestBody OtpVerifyDto request) {
-        boolean isValid = otpService.verifyOtp(request.getPhone(), request.getOtp());
+        // Validate that either phone or email is provided
+        if ((request.getPhone() == null || request.getPhone().trim().isEmpty()) &&
+            (request.getEmail() == null || request.getEmail().trim().isEmpty())) {
+            Map<String, String> error = new HashMap<>();
+            error.put("error", "Either phone number or email is required");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+        }
+
+        boolean isValid;
+        String identifier;
+        String identifierType;
+
+        if (request.getPhone() != null && !request.getPhone().trim().isEmpty()) {
+            isValid = otpService.verifyOtp(request.getPhone(), request.getOtp());
+            identifier = request.getPhone();
+            identifierType = "phone";
+        } else {
+            isValid = otpService.verifyOtpByEmail(request.getEmail(), request.getOtp());
+            identifier = request.getEmail();
+            identifierType = "email";
+        }
 
         if (!isValid) {
             Map<String, String> error = new HashMap<>();
@@ -52,11 +86,21 @@ public class AuthController {
         }
 
         // Resolve user (Teacher or Student)
-        Optional<Teacher> teacherOpt = teacherRepository.findByPhone(request.getPhone());
-        Optional<Student> studentOpt = studentRepository.findByPhone(request.getPhone());
+        Optional<Teacher> teacherOpt;
+        Optional<Student> studentOpt;
+
+        if ("phone".equals(identifierType)) {
+            teacherOpt = teacherRepository.findByPhone(identifier);
+            studentOpt = studentRepository.findByPhone(identifier);
+        } else {
+            teacherOpt = teacherRepository.findByEmail(identifier);
+            studentOpt = studentRepository.findByEmail(identifier);
+        }
 
         Long userId;
         String role;
+        String phoneNumber = null;
+        String email = null;
 
         if (teacherOpt.isPresent()) {
             Teacher teacher = teacherOpt.get();
@@ -67,6 +111,8 @@ public class AuthController {
             }
             userId = teacher.getId();
             role = "ROLE_TEACHER";
+            phoneNumber = teacher.getPhone();
+            email = teacher.getEmail();
         } else if (studentOpt.isPresent()) {
             Student student = studentOpt.get();
             if (!student.getIsActive()) {
@@ -76,20 +122,26 @@ public class AuthController {
             }
             userId = student.getId();
             role = "ROLE_STUDENT";
+            phoneNumber = student.getPhone();
+            email = student.getEmail();
         } else {
             Map<String, String> error = new HashMap<>();
-            error.put("error", "User not found with phone number: " + request.getPhone());
+            error.put("error", "User not found with " + identifierType + ": " + identifier);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
         }
 
-        // Generate JWT token
-        String token = jwtUtil.generateToken(userId, role, request.getPhone());
+        // Generate JWT token (use phone if available, otherwise email)
+        String tokenIdentifier = phoneNumber != null ? phoneNumber : email;
+        String token = jwtUtil.generateToken(userId, role, tokenIdentifier);
 
         AuthResponseDto response = new AuthResponseDto();
         response.setToken(token);
         response.setUserId(userId);
         response.setRole(role);
-        response.setPhoneNumber(request.getPhone());
+        response.setPhoneNumber(phoneNumber);
+        if (email != null) {
+            response.setEmail(email);
+        }
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/school/erp/domain/entity/OtpRequest.java
+++ b/backend/src/main/java/com/school/erp/domain/entity/OtpRequest.java
@@ -25,8 +25,11 @@ public class OtpRequest extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
+    @Column(length = 20)
     private String phoneNumber;
+
+    @Column(length = 100)
+    private String email;
 
     @Column(nullable = false, length = 255)
     private String otpHash;

--- a/backend/src/main/java/com/school/erp/dto/AuthResponseDto.java
+++ b/backend/src/main/java/com/school/erp/dto/AuthResponseDto.java
@@ -14,4 +14,5 @@ public class AuthResponseDto {
     private Long userId;
     private String role;
     private String phoneNumber;
+    private String email;
 }

--- a/backend/src/main/java/com/school/erp/dto/OtpRequestDto.java
+++ b/backend/src/main/java/com/school/erp/dto/OtpRequestDto.java
@@ -1,6 +1,6 @@
 package com.school.erp.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +13,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OtpRequestDto {
 
-    @NotBlank(message = "Phone number is required")
     @Pattern(regexp = "^[+]?[0-9\\s\\-()]{10,20}$", message = "Phone number format is invalid")
     private String phone;
+
+    @Email(message = "Email should be valid")
+    private String email;
 }

--- a/backend/src/main/java/com/school/erp/dto/OtpVerifyDto.java
+++ b/backend/src/main/java/com/school/erp/dto/OtpVerifyDto.java
@@ -1,5 +1,6 @@
 package com.school.erp.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -13,9 +14,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OtpVerifyDto {
 
-    @NotBlank(message = "Phone number is required")
     @Pattern(regexp = "^[+]?[0-9\\s\\-()]{10,20}$", message = "Phone number format is invalid")
     private String phone;
+
+    @Email(message = "Email should be valid")
+    private String email;
 
     @NotBlank(message = "OTP is required")
     @Pattern(regexp = "^[0-9]{6}$", message = "OTP must be 6 digits")

--- a/backend/src/main/java/com/school/erp/repository/OtpRequestRepository.java
+++ b/backend/src/main/java/com/school/erp/repository/OtpRequestRepository.java
@@ -15,7 +15,14 @@ public interface OtpRequestRepository extends JpaRepository<OtpRequest, Long> {
     Optional<OtpRequest> findFirstByPhoneNumberAndIsUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(
             String phoneNumber, Instant now);
 
+    Optional<OtpRequest> findFirstByEmailAndIsUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(
+            String email, Instant now);
+
     @Modifying
     @Query("UPDATE OtpRequest o SET o.isUsed = true WHERE o.phoneNumber = ?1 AND o.isUsed = false")
     void markAllAsUsedByPhoneNumber(String phoneNumber);
+
+    @Modifying
+    @Query("UPDATE OtpRequest o SET o.isUsed = true WHERE o.email = ?1 AND o.isUsed = false")
+    void markAllAsUsedByEmail(String email);
 }

--- a/backend/src/main/java/com/school/erp/repository/StudentRepository.java
+++ b/backend/src/main/java/com/school/erp/repository/StudentRepository.java
@@ -26,4 +26,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     List<Student> findByIsActive(Boolean isActive);
 
     Optional<Student> findByPhone(String phone);
+
+    Optional<Student> findByEmail(String email);
 }

--- a/backend/src/main/java/com/school/erp/service/EmailService.java
+++ b/backend/src/main/java/com/school/erp/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.school.erp.service;
+
+public interface EmailService {
+    void sendOtp(String email, String otp);
+}

--- a/backend/src/main/java/com/school/erp/service/EmailServiceImpl.java
+++ b/backend/src/main/java/com/school/erp/service/EmailServiceImpl.java
@@ -1,0 +1,32 @@
+package com.school.erp.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendOtp(String email, String otp) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setFrom("noreply.eschool365@gmail.com");
+            message.setTo(email);
+            message.setSubject("E-School OTP Verification");
+            message.setText("Your OTP for E-School login is: " + otp + "\n\nThis OTP is valid for 15 minutes.\n\nDo not share this OTP with anyone.");
+            
+            mailSender.send(message);
+            log.info("OTP email sent successfully to: {} with OTP: {}", email, otp);
+        } catch (Exception e) {
+            log.error("Failed to send OTP email to: {}", email, e);
+            throw new RuntimeException("Failed to send OTP email", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/school/erp/service/OtpService.java
+++ b/backend/src/main/java/com/school/erp/service/OtpService.java
@@ -18,11 +18,12 @@ import java.util.Optional;
 public class OtpService {
 
     private static final int OTP_LENGTH = 6;
-    private static final int OTP_VALIDITY_MINUTES = 10;
+    private static final int OTP_VALIDITY_MINUTES = 15;
     private static final int MAX_ATTEMPTS = 5;
 
     private final OtpRequestRepository otpRequestRepository;
     private final SmsService smsService;
+    private final EmailService emailService;
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private final SecureRandom random = new SecureRandom();
 
@@ -52,10 +53,69 @@ public class OtpService {
         return otp;
     }
 
+    public String generateAndSendOtpByEmail(String email) {
+        // Invalidate previous unused OTPs for this email
+        otpRequestRepository.markAllAsUsedByEmail(email);
+
+        // Generate numeric OTP
+        String otp = generateNumericOtp();
+
+        // Hash the OTP
+        String otpHash = passwordEncoder.encode(otp);
+
+        // Create OTP request
+        OtpRequest otpRequest = new OtpRequest();
+        otpRequest.setEmail(email);
+        otpRequest.setOtpHash(otpHash);
+        otpRequest.setExpiresAt(Instant.now().plusSeconds(OTP_VALIDITY_MINUTES * 60L));
+        otpRequest.setAttemptCount(0);
+        otpRequest.setIsUsed(false);
+
+        otpRequestRepository.save(otpRequest);
+
+        // Send OTP via Email
+        emailService.sendOtp(email, otp);
+
+        return otp;
+    }
+
     public boolean verifyOtp(String phoneNumber, String otp) {
         Optional<OtpRequest> otpRequestOpt = otpRequestRepository
             .findFirstByPhoneNumberAndIsUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(
                 phoneNumber, Instant.now());
+
+        if (otpRequestOpt.isEmpty()) {
+            return false;
+        }
+
+        OtpRequest otpRequest = otpRequestOpt.get();
+
+        // Check attempt count
+        if (otpRequest.getAttemptCount() >= MAX_ATTEMPTS) {
+            otpRequest.setIsUsed(true);
+            otpRequestRepository.save(otpRequest);
+            return false;
+        }
+
+        // Verify OTP
+        boolean isValid = passwordEncoder.matches(otp, otpRequest.getOtpHash());
+
+        // Increment attempt count
+        otpRequest.setAttemptCount(otpRequest.getAttemptCount() + 1);
+
+        if (isValid) {
+            otpRequest.setIsUsed(true);
+        }
+
+        otpRequestRepository.save(otpRequest);
+
+        return isValid;
+    }
+
+    public boolean verifyOtpByEmail(String email, String otp) {
+        Optional<OtpRequest> otpRequestOpt = otpRequestRepository
+            .findFirstByEmailAndIsUsedFalseAndExpiresAtAfterOrderByCreatedAtDesc(
+                email, Instant.now());
 
         if (otpRequestOpt.isEmpty()) {
             return false;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,3 +39,19 @@ logging:
 jwt:
   secret: SchoolErpSecretKeyForJWTTokenGenerationMustBeAtLeast256BitsLongForProductionUse
   expiration-minutes: 600
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: noreply.eschool365@gmail.com
+    password: fuckOff@69
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000

--- a/backend/src/main/resources/db/migration/V11__Add_Email_Support_To_OTP.sql
+++ b/backend/src/main/resources/db/migration/V11__Add_Email_Support_To_OTP.sql
@@ -1,0 +1,12 @@
+-- Add email support to OTP requests
+ALTER TABLE otp_requests 
+    ADD COLUMN email VARCHAR(100),
+    ALTER COLUMN phone_number DROP NOT NULL;
+
+-- Create index for email lookups
+CREATE INDEX IF NOT EXISTS idx_otp_requests_email ON otp_requests(email);
+
+-- Add constraint to ensure either phone or email is provided
+ALTER TABLE otp_requests 
+    ADD CONSTRAINT chk_otp_phone_or_email 
+    CHECK (phone_number IS NOT NULL OR email IS NOT NULL);


### PR DESCRIPTION
- Added Spring Mail dependency for email functionality
- Created EmailService interface and implementation
- Updated OtpRequest entity to support email (phoneNumber now nullable)
- Added database migration V11 for email support in OTP table
- Updated OtpService to support both phone and email OTP generation/verification
- Modified AuthController to handle email-based OTP requests and verification
- Updated DTOs (OtpRequestDto, OtpVerifyDto, AuthResponseDto) to support email
- Added MailConfig with Gmail SMTP configuration
- Updated OTP expiration to 15 minutes
- Added email lookup methods to repositories (TeacherRepository, StudentRepository)
- Email OTP fully integrated into login API alongside phone OTP